### PR TITLE
Make statsd optional for all services

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+    pre:
+        - pip install --upgrade setuptools

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,3 @@
 machine:
     python:
         version: 2.7.3
-
-dependencies:
-    pre:
-        - pip install --upgrade pip==6.1.1 setuptools==15.0 wheel==0.24.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
     python:
         version: 2.7.3
+
+dependencies:
+    pre:
+        - pip install --upgrade pip==6.1.1 setuptools==15.0 wheel==0.24.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+    python:
+        version: 2.7.3

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-    python:
-        version: 2.7.3

--- a/dripconfig/builtins.py
+++ b/dripconfig/builtins.py
@@ -83,8 +83,8 @@ class StatsdConfig(SchemaBasedTrigger):
         'statsd': {
             Required('host'): basestring,
             Required('port', default=8125): Coerce(int),
-            Optional('sample_rate', default=1): Coerce(int),
-            Optional('disabled', default=False): bool,
+            Optional('sample_rate'): Coerce(int),
+            Optional('disabled'): bool,
         },
     })
 

--- a/dripconfig/builtins.py
+++ b/dripconfig/builtins.py
@@ -4,7 +4,7 @@ dumped some common stuff in here for now.
 
 from logging.config import dictConfig
 
-from voluptuous import Schema, Coerce, Required, Optional
+from voluptuous import Schema, Coerce, Required, Optional, Boolean
 
 from dripconfig.interfaces import SchemaBasedTrigger
 
@@ -84,7 +84,7 @@ class StatsdConfig(SchemaBasedTrigger):
             Required('host', default='localhost'): basestring,
             Required('port', default=8125): Coerce(int),
             Optional('sample_rate'): Coerce(int),
-            Optional('disabled'): bool,
+            Optional('disabled'): Boolean,
         },
     })
 

--- a/dripconfig/builtins.py
+++ b/dripconfig/builtins.py
@@ -81,7 +81,7 @@ class StatsdConfig(SchemaBasedTrigger):
     """
     partial_schema = Schema({
         'statsd': {
-            Required('host'): basestring,
+            Required('host', default='localhost'): basestring,
             Required('port', default=8125): Coerce(int),
             Optional('sample_rate'): Coerce(int),
             Optional('disabled'): bool,
@@ -89,27 +89,8 @@ class StatsdConfig(SchemaBasedTrigger):
     })
 
     def configure(self, configuration):
-        """
-        If statsd is missing from the config, the emission of
-        data will be disabled by default. Otherwise, use the provided defaults,
-        or use the values specified in the config.
-        """
         import statsd
-
-        statsd_in_conf = 'statsd' in configuration
-        defaults = {
-            'host': 'localhost',
-            'port': 8125,
-            'sample_rate': 1,
-            'disabled': not statsd_in_conf
-        }
-
-        if statsd_in_conf:
-            for key in defaults.keys():
-                if hasattr(configuration.statsd, key):
-                    defaults[key] = getattr(configuration.statsd, key)
-
-        statsd.Connection.set_defaults(**defaults)
+        statsd.Connection.set_defaults(**configuration.get('statsd', {}))
 
 
 def register_all(config):

--- a/dripconfig/builtins.py
+++ b/dripconfig/builtins.py
@@ -84,7 +84,7 @@ class StatsdConfig(SchemaBasedTrigger):
             Required('host', default='localhost'): basestring,
             Required('port', default=8125): Coerce(int),
             Optional('sample_rate'): Coerce(int),
-            Optional('disabled'): Boolean,
+            Optional('disabled'): Boolean(basestring),
         },
     })
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         ],
     },
     tests_require=[
-        'setuptools>=17.1',
         'mock',
     ],
     dependency_links=[],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
     },
     tests_require=[
-        'mock',
+        'mock==1.0.1',
     ],
     dependency_links=[],
     packages=find_packages(exclude=['ez_setup']),

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         ],
     },
     tests_require=[
+        'setuptools>=17.1',
         'mock',
     ],
     dependency_links=[],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='dripconfig',
-    version='0.1.dev2',
+    version='0.2.dev1',
     description="configuration loading utilities for common process setup tasks",
     license="",
     author="Luke Tucker, James O'Beirne",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='dripconfig',
-    version='0.2.dev1',
+    version='0.2.0',
     description="configuration loading utilities for common process setup tasks",
     license="",
     author="Luke Tucker, James O'Beirne",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
     },
     tests_require=[
-        'mock==1.0.1',
+        'mock',
     ],
     dependency_links=[],
     packages=find_packages(exclude=['ez_setup']),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='dripconfig',
-    version='0.1.dev1',
+    version='0.1.dev2',
     description="configuration loading utilities for common process setup tasks",
     license="",
     author="Luke Tucker, James O'Beirne",


### PR DESCRIPTION
https://app.asana.com/0/32572848394828/46326836696759

Added some missing defaults (all optional), and disables the emission of data if statsd is missing from the config section, or explicitly disabled.

## QA
- [ ] unittests sufficient? 