### PR TITLE
Add forgotten exports to __init__.py

### DIFF
--- a/dripconfig/__init__.py
+++ b/dripconfig/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     'EnvVar',
     'Filename',
     'SysLogHandler',
+    'StatsdHandler',
+    'StatsdErrorFilter',
     'ToBeInjected',
     'config'
 ]
@@ -25,4 +27,4 @@ __all__ = [
 
 config = ConfigDict()
 
-__version__ = '0.2.3'
+__version__ = '0.2.5'

--- a/dripconfig/__init__.py
+++ b/dripconfig/__init__.py
@@ -8,7 +8,7 @@ from .sources import (
     EnvVar,
     Filename,
 )
-from .helpers import SysLogHandler
+from .helpers import SysLogHandler, StatsdHandler, StatsdErrorFilter
 from .interfaces import ConfigurationTrigger, ToBeInjected
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name='dripconfig',
-    version='0.2.4',
+    version='0.2.5',
     description="configuration loading utilities for common process setup tasks",
     license="",
     author="Luke Tucker, James O'Beirne",


### PR DESCRIPTION
Missed the __init__ bit in my original PR.  